### PR TITLE
Add AGENTS.md with Cursor Cloud development setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# mobile-combat
+
+A 3D fighting game built with [Astro](https://astro.build/) and [Three.js](https://threejs.org/). It renders a single page (`src/pages/index.astro`) that mounts a WebGL canvas; all game logic lives under `src/` (game loop in `src/scene.ts`, `src/game.ts`, `src/player.ts`). 3D assets (models, animations, textures) are served from `public/assets`.
+
+## Cursor Cloud specific instructions
+
+### Tooling
+- Package manager is **Yarn (classic, v1)** — a `yarn.lock` is committed. Use `yarn`, not npm.
+- `.nvmrc` pins Node v19, but that version is not installed in this environment. Node v22 (the available version) installs, lints, builds, and runs the dev server without issues, so there is no need to install Node 19.
+
+### Commands (see `package.json` scripts)
+- Dev server: `yarn dev` — starts Astro on `http://localhost:3000`. Use `yarn dev --host 0.0.0.0` to expose it on the network. This is a static single-page app; there is no backend service.
+- Lint: `yarn lint` — runs `eslint src --ext=.ts --fix`. Note the `--fix` flag means linting can rewrite source files in place.
+- Build: `yarn build` — outputs a static site to `dist/`.
+- There is no automated test suite in this repository.
+
+### Running / testing the game (non-obvious)
+- The game is a 3D scene rendered to a `<canvas>`. Keyboard controls are bound to the canvas element, so you must **click the canvas first to give it focus** before key presses register.
+- Default Player 1 controls: `A`/`D` move, `Space` jump, `G` punch up, `V` punch down. Player 2 uses arrow keys, `Equal`/`BracketRight` to punch, etc. (defined in `src/stores/settings.ts`).
+- The debug overlay (top-left text showing game status, player life, round timer, scores, plus collider wireframes) is **hidden by default**. There is no in-game UI to toggle it. To enable it for testing, set the persisted setting in the browser console and reload:
+  ```js
+  localStorage.setItem('settings', JSON.stringify({debug:true,inputs:{player1:{left:"KeyA",right:"KeyD",jump:"Space",attackUp:"KeyG",attackDown:"KeyV",block:"KeyY"},player2:{left:"ArrowLeft",right:"ArrowRight",jump:"ControlRight",attackUp:"Equal",attackDown:"BracketRight",block:"Backslash"},menu:"Escape"},inputType:"keyboard"}))
+  ```
+  The live round timer counting down (once per second) is a quick way to confirm the game loop is running.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up and documents the development environment for this Astro + Three.js fighting game. No application code was changed — only adds `AGENTS.md` with durable, non-obvious setup/run notes for future agents.

## Environment setup verified
- **Package manager:** Yarn classic (`yarn.lock`); Node v22 (repo `.nvmrc` pins v19 which is unavailable, but v22 works for install/lint/build/dev).
- **Update script (configured separately):** `yarn install --frozen-lockfile`.

## Checks run
- `yarn lint` — passed (eslint, no changes).
- `yarn build` — passed (static site to `dist/`).
- `yarn dev` — serves the game on `http://localhost:3000`.

## Hello-world demonstration
Loaded the game in Chrome: the 3D Mayan-temple scene rendered with two fighters, the built-in debug overlay (enabled via `localStorage`) showed live game state with the round timer counting down (76 → 60), and holding `D` switched Player 1 into a walking animation and moved them rightward.

[mobile_combat_dev_demo.mp4](https://cursor.com/agents/bc-d6deb837-8738-477c-aea2-543ac0b178ad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_combat_dev_demo.mp4)

[Game running with debug overlay, round timer 76](https://cursor.com/agents/bc-d6deb837-8738-477c-aea2-543ac0b178ad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdebug_overlay_round_28.webp)
[Player 1 in walking pose after pressing D, round timer 60](https://cursor.com/agents/bc-d6deb837-8738-477c-aea2-543ac0b178ad/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplayer1_walking.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d6deb837-8738-477c-aea2-543ac0b178ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6deb837-8738-477c-aea2-543ac0b178ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

