### PR TITLE
Add GitHub Pages deployment workflow and update README

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# mobile-combat
+# Mobile Combat
+
+A 3D browser fighting game built with [Astro](https://astro.build/) and [Three.js](https://threejs.org/). Two players battle locally on a Mayan Temple arena with keyboard controls, round-based scoring, and animated combat.
+
+**Play online:** https://gilsonmandalogo.github.io/mobile-combat/
+
+## Controls
+
+Click the game canvas to focus it before using the keyboard.
+
+| Action | Player 1 | Player 2 |
+|--------|----------|----------|
+| Move left / right | `A` / `D` | `←` / `→` |
+| Jump | `Space` | `Right Ctrl` |
+| Punch up / down | `G` / `V` | `=` / `]` |
+| Block | `Y` | `\` |
+
+## Local development
+
+```bash
+yarn install
+yarn dev
+```
+
+Open http://localhost:3000 to play locally. Build the static site with:
+
+```bash
+yarn build
+```
+
+## Deployment
+
+The site is automatically deployed to GitHub Pages whenever changes are pushed to the `main` branch via the [deploy workflow](.github/workflows/deploy.yml).

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,6 @@
+import { defineConfig } from 'astro/config'
+
+export default defineConfig({
+  site: 'https://gilsonmandalogo.github.io',
+  base: '/mobile-combat/',
+})

--- a/src/animations.ts
+++ b/src/animations.ts
@@ -1,5 +1,6 @@
 import type * as THREE from 'three'
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
+import { assetUrl } from '@src/utils'
 
 const ANIMATION_FILES = ['Idle', 'WalkForward', 'WalkBackward', 'PunchUp', 'PunchDown']
 
@@ -13,7 +14,7 @@ export default class Animations {
     const loader = new GLTFLoader()
 
     for (const file of ANIMATION_FILES) {
-      const gltf = await loader.loadAsync(`assets/animations/${file}.glb`)
+      const gltf = await loader.loadAsync(assetUrl(`assets/animations/${file}.glb`))
       this._animations = {
         ...this._animations,
         [file]: gltf.animations[0],

--- a/src/hero.ts
+++ b/src/hero.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three'
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
 import { ErrorUndefinedProperty } from '@src/errors'
+import { assetUrl } from '@src/utils'
 
 export enum HeroName {
   MrColinCole = 'Mr Colin Cole',
@@ -68,7 +69,7 @@ export default abstract class Hero {
 
   public async loadMesh() {
     const loader = new GLTFLoader()
-    const model = await loader.loadAsync(`assets/models/${this.name.replaceAll(' ', '-')}.glb`)
+    const model = await loader.loadAsync(assetUrl(`assets/models/${this.name.replaceAll(' ', '-')}.glb`))
 
     model.scene.traverse(child => {
       if (child instanceof THREE.Mesh && child.isMesh) {

--- a/src/level.ts
+++ b/src/level.ts
@@ -1,4 +1,5 @@
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
+import { assetUrl } from '@src/utils'
 
 export const allLevels = ['Mayan-Temple'] as const
 export type LevelName = typeof allLevels[number]
@@ -8,7 +9,7 @@ export default abstract class Level {
 
   public async loadLevel() {
     const loader = new GLTFLoader()
-    const model = await loader.loadAsync(`assets/models/${this.levelName}.glb`)
+    const model = await loader.loadAsync(assetUrl(`assets/models/${this.levelName}.glb`))
     return model
   }
 

--- a/src/particles/fire/fire.ts
+++ b/src/particles/fire/fire.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three'
+import { assetUrl } from '@src/utils'
 import vertexShader from './vertex.glsl?raw'
 import fragmentShader from './fragment.glsl?raw'
 
@@ -38,7 +39,7 @@ export default class FireParticleSystem {
   constructor(params: FireParticleSystemConstructor) {
     const uniforms = {
       diffuseTexture: {
-        value: new THREE.TextureLoader().load('assets/textures/fire.png')
+        value: new THREE.TextureLoader().load(assetUrl('assets/textures/fire.png'))
       },
       pointMultiplier: {
         value: window.innerHeight / (2.0 * Math.tan(0.5 * 120.0 * Math.PI / 180.0))

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,9 @@
 import type { HeroName } from '@src/hero'
+
+export function assetUrl(path: string) {
+  return `${import.meta.env.BASE_URL}${path.replace(/^\//, '')}`
+}
+
 import MrColinCole from '@heroes/MrColinCole'
 import type { LevelName } from '@src/level'
 import MayanTempleLevel from '@levels/mayanTemple'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds a GitHub Actions workflow that builds and deploys the Astro site to GitHub Pages on every push to `main`
- Configures Astro with the correct `base` path (`/mobile-combat/`) for project-site hosting
- Fixes Three.js asset loading to respect the GitHub Pages subpath via a shared `assetUrl` helper
- Expands `README.md` with a project summary, controls, local dev instructions, and the live demo link

## Live URL

After merging and enabling GitHub Pages (Settings → Pages → Deploy from GitHub Actions), the site will be available at:

https://gilsonmandalogo.github.io/mobile-combat/

## Manual step required

In the repository settings, set **Pages → Build and deployment → Source** to **GitHub Actions** before the first deploy can succeed.

## Test plan

- [x] `yarn build` completes successfully locally
- [x] Built assets reference `/mobile-combat/` base path
- [ ] Merge to `main` and confirm the deploy workflow succeeds
- [ ] Verify the live site loads at the GitHub Pages URL

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53ad6cbb-3da7-47d5-be87-4459c387db04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53ad6cbb-3da7-47d5-be87-4459c387db04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

